### PR TITLE
build: run lint on Go 1.17

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
         with:
           go-version: '1.16'
       - uses: actions/checkout@v2
-      - run: make test
+      - run: make ginkgo
   test-go-1-17:
     runs-on: ubuntu-latest
     steps:
@@ -18,7 +18,7 @@ jobs:
         with:
           go-version: '1.17'
       - uses: actions/checkout@v2
-      - run: make ginkgo
+      - run: make test
   test-go-1-18:
     runs-on: ubuntu-latest
     steps:

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 package tools


### PR DESCRIPTION
It seems that staticheck no longer works on Go 1.16