### PR TITLE
chore: add Go 1.19 to test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,17 +1,8 @@
 name: test
-
 on: [push, pull_request]
-
 jobs:
-  test-go-1-16:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/setup-go@v3
-        with:
-          go-version: '1.16'
-      - uses: actions/checkout@v3
-      - run: make ginkgo
-  test-go-1-17:
+  test-and-lint:
+    name: Test and Lint Go 1.17
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-go@v3
@@ -19,12 +10,15 @@ jobs:
           go-version: '1.17'
       - uses: actions/checkout@v3
       - run: make test
-  test-go-1-18:
+  test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: [ '1.16', '1.18', '1.19' ]
+    name: Test Go ${{ matrix.go }}
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: ${{ matrix.go }}
       - uses: actions/checkout@v3
       - run: make ginkgo
-


### PR DESCRIPTION
As the main consumer is the CF CLI, we should still test against
unsupported versions of Go as the CF CLI is often built with old
versions