### PR TITLE
build: drop Go 1.16 and Go 1.17 testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,19 +2,19 @@ name: test
 on: [push, pull_request]
 jobs:
   test-and-lint:
-    name: Test and Lint Go 1.17
+    name: Test and Lint Go 1.18
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.17'
+          go-version: '1.18'
       - uses: actions/checkout@v3
       - run: make test
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.16', '1.18', '1.19' ]
+        go: [ '1.19' ]
     name: Test Go ${{ matrix.go }}
     steps:
       - uses: actions/setup-go@v3


### PR DESCRIPTION
github.com/onsi/gomega 1.23.0 does not work with Go 1.16 or Go 1.17 github.com/onsi/ginkgo/v2 2.4.0 does not work with Go 1.16

So testing is now done only with Go 1.18 and Go 1.19 which are the current versions in support by the Go team.

Go 1.17 error
```
Error: ../../../go/pkg/mod/github.com/onsi/gomega@v1.23.0/internal/polling_signal_error.go:19:33: undefined: any
Error: ../../../go/pkg/mod/github.com/onsi/gomega@v1.23.0/internal/polling_signal_error.go:40:14: undefined: any
Error: ../../../go/pkg/mod/github.com/onsi/gomega@v1.23.0/internal/polling_signal_error.go:56:65: undefined: any
```

Go 1.16 error:
```
Error: ../../../go/pkg/mod/golang.org/x/sys@v0.1.0/unix/syscall.go:83:16: undefined: unsafe.Slice
Error: ../../../go/pkg/mod/golang.org/x/sys@v0.1.0/unix/syscall_linux.go:2255:9: undefined: unsafe.Slice
Error: ../../../go/pkg/mod/golang.org/x/sys@v0.1.0/unix/syscall_unix.go:118:7: undefined: unsafe.Slice
Error: ../../../go/pkg/mod/golang.org/x/sys@v0.1.0/unix/sysvshm_unix.go:33:7: undefined: unsafe.Slice
```