### PR TITLE
chore: update test matrix for Go 1.21

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,19 +2,19 @@ name: test
 on: [push, pull_request]
 jobs:
   test-and-lint:
-    name: Test and Lint Go 1.19
+    name: Test and Lint Go 1.20
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.19'
+          go-version: '1.20'
       - uses: actions/checkout@v3
       - run: make test
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.20' ]
+        go: [ '1.21' ]
     name: Test Go ${{ matrix.go }}
     steps:
       - uses: actions/setup-go@v4


### PR DESCRIPTION
Go 1.21 has just been released.
Implicitly, Go 1.19 is now out of support.