### PR TITLE
chore: use reflect.PointerTo() rather than PtrTo()

### DIFF
--- a/unmarshal.go
+++ b/unmarshal.go
@@ -72,7 +72,7 @@ func unmarshal(target reflect.Value, found bool, source interface{}) error {
 
 	var err error
 	switch {
-	case reflect.PtrTo(target.Type()).Implements(reflect.TypeOf((*json.Unmarshaler)(nil)).Elem()):
+	case reflect.PointerTo(target.Type()).Implements(reflect.TypeOf((*json.Unmarshaler)(nil)).Elem()):
 		err = unmarshalIntoJSONUnmarshaler(target, found, source)
 	case basicType(kind), kind == reflect.Interface:
 		err = unmarshalInfoLeaf(target, found, source)


### PR DESCRIPTION
reflect.PtrTo() is deprecated and has been replaced by reflect.PointerTo()