### PR TITLE
chore: apply fixes from Go modernize command

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -10,9 +10,9 @@ import (
 )
 
 type container struct {
-	A []int       `jsonry:"a"`
-	C interface{} `jsonry:"b.c"`
-	D string      `jsonry:"b.d"`
+	A []int  `jsonry:"a"`
+	C any    `jsonry:"b.c"`
+	D string `jsonry:"b.d"`
 }
 
 const marshaled = `{"a":[1,2,3],"b":{"c":null,"d":"hello"}}`
@@ -48,8 +48,8 @@ func BenchmarkUnmarshal(b *testing.B) {
 			var receiver struct {
 				A []int `json:"a"`
 				B struct {
-					C interface{} `json:"c"`
-					D string      `json:"d"`
+					C any    `json:"c"`
+					D string `json:"d"`
 				} `json:"b"`
 			}
 			json.Unmarshal([]byte(marshaled), &receiver)
@@ -92,8 +92,8 @@ func BenchmarkMarshal(b *testing.B) {
 			var transmitter struct {
 				A []int `json:"a"`
 				B struct {
-					C interface{} `json:"c"`
-					D string      `json:"d"`
+					C any    `json:"c"`
+					D string `json:"d"`
 				} `json:"b"`
 			}
 			transmitter.A = u.A

--- a/errors.go
+++ b/errors.go
@@ -45,10 +45,10 @@ func (u unsupportedKeyType) message(ctx errorcontext.ErrorContext) string {
 }
 
 type conversionError struct {
-	value interface{}
+	value any
 }
 
-func newConversionError(value interface{}) error {
+func newConversionError(value any) error {
 	return &conversionError{
 		value: value,
 	}

--- a/internal/tree/tree.go
+++ b/internal/tree/tree.go
@@ -7,9 +7,9 @@ import (
 	"code.cloudfoundry.org/jsonry/internal/path"
 )
 
-type Tree map[string]interface{}
+type Tree map[string]any
 
-func (t Tree) Attach(p path.Path, v interface{}) Tree {
+func (t Tree) Attach(p path.Path, v any) Tree {
 	switch p.Len() {
 	case 0:
 		panic("empty path")
@@ -31,7 +31,7 @@ func (t Tree) Attach(p path.Path, v interface{}) Tree {
 	return t
 }
 
-func (t Tree) Fetch(p path.Path) (interface{}, bool) {
+func (t Tree) Fetch(p path.Path) (any, bool) {
 	switch p.Len() {
 	case 0:
 		panic("empty path")
@@ -47,9 +47,9 @@ func (t Tree) Fetch(p path.Path) (interface{}, bool) {
 		}
 
 		switch vt := v.(type) {
-		case map[string]interface{}:
+		case map[string]any:
 			return Tree(vt).Fetch(stem)
-		case []interface{}:
+		case []any:
 			return unspread(vt, stem), true
 		default:
 			return nil, false
@@ -57,31 +57,31 @@ func (t Tree) Fetch(p path.Path) (interface{}, bool) {
 	}
 }
 
-func spread(p path.Path, v interface{}) []interface{} {
+func spread(p path.Path, v any) []any {
 	vv := reflect.ValueOf(v)
 	if vv.Kind() != reflect.Array && vv.Kind() != reflect.Slice {
-		v = []interface{}{v}
+		v = []any{v}
 		vv = reflect.ValueOf(v)
 	}
 
-	var s []interface{}
+	var s []any
 	for i := 0; i < vv.Len(); i++ {
 		s = append(s, make(Tree).Attach(p, vv.Index(i).Interface()))
 	}
 	return s
 }
 
-func unspread(v []interface{}, stem path.Path) []interface{} {
-	l := make([]interface{}, 0, len(v))
+func unspread(v []any, stem path.Path) []any {
+	l := make([]any, 0, len(v))
 	for i := range v {
 		switch vt := v[i].(type) {
-		case map[string]interface{}:
+		case map[string]any:
 			if r, ok := Tree(vt).Fetch(stem); ok {
 				l = append(l, r)
 			} else {
 				l = append(l, nil)
 			}
-		case []interface{}:
+		case []any:
 			l = append(l, unspread(vt, stem)...)
 		default:
 			l = append(l, v[i])

--- a/internal/tree/tree_test.go
+++ b/internal/tree/tree_test.go
@@ -78,7 +78,7 @@ var _ = Describe("Tree", func() {
 
 			v, ok := t.Fetch(p)
 			Expect(ok).To(BeTrue())
-			Expect(v).To(Equal(map[string]interface{}{"d": map[string]interface{}{"e": "hello"}}))
+			Expect(v).To(Equal(map[string]any{"d": map[string]any{"e": "hello"}}))
 		})
 
 		It("can fetch a list at the leaf", func() {
@@ -88,7 +88,7 @@ var _ = Describe("Tree", func() {
 
 			v, ok := t.Fetch(p)
 			Expect(ok).To(BeTrue())
-			Expect(v).To(Equal([]interface{}{"h", "e", "l", "l", "o"}))
+			Expect(v).To(Equal([]any{"h", "e", "l", "l", "o"}))
 		})
 
 		It("can fetch a list at a branch", func() {
@@ -98,7 +98,7 @@ var _ = Describe("Tree", func() {
 
 			v, ok := t.Fetch(p)
 			Expect(ok).To(BeTrue())
-			Expect(v).To(Equal([]interface{}{"h", "i", "!"}))
+			Expect(v).To(Equal([]any{"h", "i", "!"}))
 		})
 
 		It("inserts nils when a list has missing elements", func() {
@@ -108,7 +108,7 @@ var _ = Describe("Tree", func() {
 
 			v, ok := t.Fetch(p)
 			Expect(ok).To(BeTrue())
-			Expect(v).To(Equal([]interface{}{"h", nil, "i", nil, "!"}))
+			Expect(v).To(Equal([]any{"h", nil, "i", nil, "!"}))
 		})
 
 		It("flattens lists of lists", func() {
@@ -118,7 +118,7 @@ var _ = Describe("Tree", func() {
 
 			v, ok := t.Fetch(p)
 			Expect(ok).To(BeTrue())
-			Expect(v).To(Equal([]interface{}{"h", nil, "i", "!"}))
+			Expect(v).To(Equal([]any{"h", nil, "i", "!"}))
 		})
 	})
 })

--- a/marshal.go
+++ b/marshal.go
@@ -21,7 +21,7 @@ import (
 // to determine whether or not to marshal the field, overriding any `,omitempty` tags.
 //
 // The field type can be string, bool, int*, uint*, float*, map, slice, array or struct. JSONry is recursive.
-func Marshal(in interface{}) ([]byte, error) {
+func Marshal(in any) ([]byte, error) {
 	iv := reflect.Indirect(reflect.ValueOf(in))
 
 	if iv.Kind() != reflect.Struct {
@@ -36,7 +36,7 @@ func Marshal(in interface{}) ([]byte, error) {
 	return json.Marshal(m)
 }
 
-func marshalStruct(in reflect.Value) (map[string]interface{}, error) {
+func marshalStruct(in reflect.Value) (map[string]any, error) {
 	out := make(tree.Tree)
 	t := in.Type()
 
@@ -61,7 +61,7 @@ func marshalStruct(in reflect.Value) (map[string]interface{}, error) {
 	return out, nil
 }
 
-func marshal(in reflect.Value) (r interface{}, err error) {
+func marshal(in reflect.Value) (r any, err error) {
 	input := reflect.Indirect(in)
 	kind := input.Kind()
 
@@ -87,12 +87,12 @@ func marshal(in reflect.Value) (r interface{}, err error) {
 	return
 }
 
-func marshalList(in reflect.Value) (out []interface{}, err error) {
+func marshalList(in reflect.Value) (out []any, err error) {
 	if in.Type().Kind() == reflect.Slice && in.IsNil() {
 		return out, nil
 	}
 
-	out = make([]interface{}, in.Len())
+	out = make([]any, in.Len())
 	for i := 0; i < in.Len(); i++ {
 		r, err := marshal(in.Index(i))
 		if err != nil {
@@ -104,12 +104,12 @@ func marshalList(in reflect.Value) (out []interface{}, err error) {
 	return out, nil
 }
 
-func marshalMap(in reflect.Value) (out map[string]interface{}, err error) {
+func marshalMap(in reflect.Value) (out map[string]any, err error) {
 	if in.IsNil() {
 		return out, nil
 	}
 
-	out = make(map[string]interface{})
+	out = make(map[string]any)
 	iter := in.MapRange()
 	for iter.Next() {
 		k := iter.Key()
@@ -127,7 +127,7 @@ func marshalMap(in reflect.Value) (out map[string]interface{}, err error) {
 	return out, nil
 }
 
-func marshalJSONMarshaler(in reflect.Value) (interface{}, error) {
+func marshalJSONMarshaler(in reflect.Value) (any, error) {
 	const method = "MarshalJSON"
 	t := in.MethodByName(method).Call(nil)
 
@@ -135,7 +135,7 @@ func marshalJSONMarshaler(in reflect.Value) (interface{}, error) {
 		return nil, newForeignError(fmt.Sprintf("error from %s() call", method), err)
 	}
 
-	var r interface{}
+	var r any
 	err := json.Unmarshal(t[0].Bytes(), &r)
 	if err != nil {
 		return nil, newForeignError(fmt.Sprintf(`error parsing %s() output "%s"`, method, t[0].Bytes()), err)

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -10,13 +10,13 @@ import (
 )
 
 var _ = Describe("Marshal", func() {
-	expectToMarshal := func(input interface{}, expected string) {
+	expectToMarshal := func(input any, expected string) {
 		out, err := jsonry.Marshal(input)
 		ExpectWithOffset(1, err).NotTo(HaveOccurred())
 		ExpectWithOffset(1, out).To(MatchJSON(expected))
 	}
 
-	expectToFail := func(input interface{}, message string) {
+	expectToFail := func(input any, message string) {
 		_, err := jsonry.Marshal(input)
 		ExpectWithOffset(1, err).To(MatchError(message), func() string {
 			if err != nil {
@@ -130,7 +130,7 @@ var _ = Describe("Marshal", func() {
 		})
 
 		It("marshals a nil interface", func() {
-			expectToMarshal(struct{ N interface{} }{N: nil}, `{"N":null}`)
+			expectToMarshal(struct{ N any }{N: nil}, `{"N":null}`)
 		})
 
 		It("marshals a nil pointer", func() {
@@ -142,18 +142,18 @@ var _ = Describe("Marshal", func() {
 		})
 
 		It("marshals an array", func() {
-			s := [3]interface{}{"hello", true, 42}
-			expectToMarshal(struct{ S [3]interface{} }{S: s}, `{"S":["hello",true,42]}`)
+			s := [3]any{"hello", true, 42}
+			expectToMarshal(struct{ S [3]any }{S: s}, `{"S":["hello",true,42]}`)
 			expectToMarshal(struct {
-				S *[3]interface{}
+				S *[3]any
 			}{S: &s}, `{"S":["hello",true,42]}`)
 		})
 
 		Context("slices", func() {
 			It("marshals slices with interface{} values", func() {
-				s := []interface{}{"hello", true, 42}
-				expectToMarshal(struct{ S []interface{} }{S: s}, `{"S":["hello",true,42]}`)
-				expectToMarshal(struct{ S *[]interface{} }{S: &s}, `{"S":["hello",true,42]}`)
+				s := []any{"hello", true, 42}
+				expectToMarshal(struct{ S []any }{S: s}, `{"S":["hello",true,42]}`)
+				expectToMarshal(struct{ S *[]any }{S: &s}, `{"S":["hello",true,42]}`)
 			})
 
 			It("marshals slices with string values", func() {
@@ -177,9 +177,9 @@ var _ = Describe("Marshal", func() {
 
 		Context("maps", func() {
 			It("marshals maps with interface{} values", func() {
-				mi := map[string]interface{}{"foo": "hello", "bar": true, "baz": 42}
-				expectToMarshal(struct{ M map[string]interface{} }{M: mi}, `{"M":{"foo":"hello","bar":true,"baz":42}}`)
-				expectToMarshal(struct{ M *map[string]interface{} }{M: &mi}, `{"M":{"foo":"hello","bar":true,"baz":42}}`)
+				mi := map[string]any{"foo": "hello", "bar": true, "baz": 42}
+				expectToMarshal(struct{ M map[string]any }{M: mi}, `{"M":{"foo":"hello","bar":true,"baz":42}}`)
+				expectToMarshal(struct{ M *map[string]any }{M: &mi}, `{"M":{"foo":"hello","bar":true,"baz":42}}`)
 			})
 
 			It("marshals maps with string values", func() {
@@ -200,8 +200,8 @@ var _ = Describe("Marshal", func() {
 			})
 
 			It("fails with invalid keys", func() {
-				mn := map[int]interface{}{4: 3}
-				expectToFail(struct{ M map[int]interface{} }{M: mn}, `maps must only have string keys for "map[int]interface {}" at field "M" (type "map[int]interface {}")`)
+				mn := map[int]any{4: 3}
+				expectToFail(struct{ M map[int]any }{M: mn}, `maps must only have string keys for "map[int]interface {}" at field "M" (type "map[int]interface {}")`)
 			})
 
 			It("marshals a map with keys that are string type definitions", func() {
@@ -284,14 +284,14 @@ var _ = Describe("Marshal", func() {
 				B *t           `jsonry:",omitempty"`
 				C *[]string    `jsonry:",omitempty"`
 				D *map[int]int `jsonry:",omitempty"`
-				E *interface{} `jsonry:",omitempty"`
+				E *any         `jsonry:",omitempty"`
 			}{}
 			expectToMarshal(s, `{}`)
 		})
 
 		It("omits nil interface values", func() {
 			s := struct {
-				A interface{}    `jsonry:",omitempty"`
+				A any            `jsonry:",omitempty"`
 				B json.Marshaler `jsonry:",omitempty"`
 			}{}
 			expectToMarshal(s, `{}`)
@@ -318,8 +318,8 @@ var _ = Describe("Marshal", func() {
 
 		It("omits empty maps", func() {
 			s := struct {
-				A map[interface{}]interface{} `jsonry:",omitempty"`
-				D map[int]int                 `jsonry:",omitempty"`
+				A map[any]any `jsonry:",omitempty"`
+				D map[int]int `jsonry:",omitempty"`
 			}{
 				D: make(map[int]int),
 			}

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -17,7 +17,7 @@ import (
 // string, bool, int*, uint*, float*, map, slice or struct. JSONry is recursive.
 //
 // If a field implements the json.Unmarshaler interface, then the UnmarshalJSON() method will be called.
-func Unmarshal(data []byte, receiver interface{}) error {
+func Unmarshal(data []byte, receiver any) error {
 	target := reflect.ValueOf(receiver)
 
 	if target.Kind() != reflect.Ptr {
@@ -29,7 +29,7 @@ func Unmarshal(data []byte, receiver interface{}) error {
 		return fmt.Errorf("receiver must be a pointer to a struct type, got: %s", target.Type())
 	}
 
-	var source map[string]interface{}
+	var source map[string]any
 
 	d := json.NewDecoder(bytes.NewBuffer(data))
 	d.UseNumber()
@@ -40,12 +40,12 @@ func Unmarshal(data []byte, receiver interface{}) error {
 	return unmarshalIntoStruct(target, true, source)
 }
 
-func unmarshalIntoStruct(target reflect.Value, found bool, source interface{}) error {
+func unmarshalIntoStruct(target reflect.Value, found bool, source any) error {
 	if !found || source == nil {
 		return nil
 	}
 
-	src, ok := source.(map[string]interface{})
+	src, ok := source.(map[string]any)
 	if !ok {
 		return newConversionError(source)
 	}
@@ -67,7 +67,7 @@ func unmarshalIntoStruct(target reflect.Value, found bool, source interface{}) e
 	return nil
 }
 
-func unmarshal(target reflect.Value, found bool, source interface{}) error {
+func unmarshal(target reflect.Value, found bool, source any) error {
 	kind := underlyingType(target).Kind()
 
 	var err error
@@ -88,7 +88,7 @@ func unmarshal(target reflect.Value, found bool, source interface{}) error {
 	return err
 }
 
-func unmarshalInfoLeaf(target reflect.Value, found bool, source interface{}) error {
+func unmarshalInfoLeaf(target reflect.Value, found bool, source any) error {
 	if !found {
 		return nil
 	}
@@ -160,12 +160,12 @@ func unmarshalInfoLeaf(target reflect.Value, found bool, source interface{}) err
 	return newConversionError(source)
 }
 
-func unmarshalIntoSlice(target reflect.Value, found bool, source interface{}) error {
+func unmarshalIntoSlice(target reflect.Value, found bool, source any) error {
 	if !found || source == nil {
 		return nil
 	}
 
-	src, ok := source.([]interface{})
+	src, ok := source.([]any)
 	if !ok {
 		return newConversionError(source)
 	}
@@ -183,7 +183,7 @@ func unmarshalIntoSlice(target reflect.Value, found bool, source interface{}) er
 	return nil
 }
 
-func unmarshalIntoMap(target reflect.Value, found bool, source interface{}) error {
+func unmarshalIntoMap(target reflect.Value, found bool, source any) error {
 	targetType := underlyingType(target)
 
 	if targetType.Key().Kind() != reflect.String {
@@ -194,7 +194,7 @@ func unmarshalIntoMap(target reflect.Value, found bool, source interface{}) erro
 		return nil
 	}
 
-	src, ok := source.(map[string]interface{})
+	src, ok := source.(map[string]any)
 	if !ok {
 		return newConversionError(source)
 	}
@@ -214,7 +214,7 @@ func unmarshalIntoMap(target reflect.Value, found bool, source interface{}) erro
 	return nil
 }
 
-func unmarshalIntoJSONUnmarshaler(target reflect.Value, found bool, source interface{}) error {
+func unmarshalIntoJSONUnmarshaler(target reflect.Value, found bool, source any) error {
 	if !found {
 		return nil
 	}
@@ -250,7 +250,7 @@ func allocateIfNeeded(target reflect.Value) reflect.Value {
 	return n.Elem()
 }
 
-func convertNumbers(input interface{}) interface{} {
+func convertNumbers(input any) any {
 	n, ok := input.(json.Number)
 	if !ok {
 		return input

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -11,12 +11,12 @@ import (
 )
 
 var _ = Describe("Unmarshal", func() {
-	unmarshal := func(receiver interface{}, json string) {
+	unmarshal := func(receiver any, json string) {
 		err := jsonry.Unmarshal([]byte(json), receiver)
 		ExpectWithOffset(1, err).NotTo(HaveOccurred())
 	}
 
-	expectToFail := func(receiver interface{}, json, message string) {
+	expectToFail := func(receiver any, json, message string) {
 		err := jsonry.Unmarshal([]byte(json), receiver)
 		ExpectWithOffset(1, err).To(MatchError(message), func() string {
 			if err != nil {
@@ -185,7 +185,7 @@ var _ = Describe("Unmarshal", func() {
 		})
 
 		It("unmarshals into an interface{} field", func() {
-			var s struct{ N, B, S, I, U, F, L, M interface{} }
+			var s struct{ N, B, S, I, U, F, L, M any }
 			unmarshal(&s, `{"N":null,"B":true,"S":"foo","I":-42,"U":12,"F":4.2,"L":[1,2],"M":{"f":"b"}}`)
 			Expect(s).To(MatchAllFields(Fields{
 				"N": BeNil(),
@@ -194,8 +194,8 @@ var _ = Describe("Unmarshal", func() {
 				"I": Equal(-42),
 				"U": Equal(12),
 				"F": Equal(4.2),
-				"L": Equal([]interface{}{json.Number("1"), json.Number("2")}),
-				"M": Equal(map[string]interface{}{"f": "b"}),
+				"L": Equal([]any{json.Number("1"), json.Number("2")}),
+				"M": Equal(map[string]any{"f": "b"}),
 			}))
 		})
 
@@ -223,15 +223,15 @@ var _ = Describe("Unmarshal", func() {
 		Context("slices", func() {
 			It("unmarshals into slices of interface{}", func() {
 				By("slice", func() {
-					var s struct{ I []interface{} }
+					var s struct{ I []any }
 					unmarshal(&s, `{"I": ["a",2,true]}`)
-					Expect(s.I).To(Equal([]interface{}{"a", 2, true}))
+					Expect(s.I).To(Equal([]any{"a", 2, true}))
 				})
 
 				By("pointer", func() {
-					var s struct{ I *[]interface{} }
+					var s struct{ I *[]any }
 					unmarshal(&s, `{"I": ["a",2,true]}`)
-					Expect(s.I).To(PointTo(Equal([]interface{}{"a", 2, true})))
+					Expect(s.I).To(PointTo(Equal([]any{"a", 2, true})))
 				})
 			})
 
@@ -265,14 +265,14 @@ var _ = Describe("Unmarshal", func() {
 
 			It("unmarshals an omitted slice", func() {
 				By("slice", func() {
-					var s struct{ I []interface{} }
+					var s struct{ I []any }
 					unmarshal(&s, `{}`)
 					Expect(s.I).To(BeNil())
 					Expect(s.I).To(BeEmpty())
 				})
 
 				By("pointer", func() {
-					var s struct{ I *[]interface{} }
+					var s struct{ I *[]any }
 					unmarshal(&s, `{}`)
 					Expect(s.I).To(BeNil())
 				})
@@ -280,14 +280,14 @@ var _ = Describe("Unmarshal", func() {
 
 			It("unmarshals a null slice", func() {
 				By("slice", func() {
-					var s struct{ I []interface{} }
+					var s struct{ I []any }
 					unmarshal(&s, `{"I": null}`)
 					Expect(s.I).To(BeNil())
 					Expect(s.I).To(BeEmpty())
 				})
 
 				By("pointer", func() {
-					var s struct{ I *[]interface{} }
+					var s struct{ I *[]any }
 					unmarshal(&s, `{"I": null}`)
 					Expect(s.I).To(BeNil())
 				})
@@ -295,14 +295,14 @@ var _ = Describe("Unmarshal", func() {
 
 			It("unmarshals an empty slice", func() {
 				By("slice", func() {
-					var s struct{ I []interface{} }
+					var s struct{ I []any }
 					unmarshal(&s, `{"I": []}`)
 					Expect(s.I).NotTo(BeNil())
 					Expect(s.I).To(BeEmpty())
 				})
 
 				By("pointer", func() {
-					var s struct{ I *[]interface{} }
+					var s struct{ I *[]any }
 					unmarshal(&s, `{"I": []}`)
 					Expect(s.I).NotTo(BeNil())
 					Expect(s.I).To(PointTo(Not(BeNil())))
@@ -314,15 +314,15 @@ var _ = Describe("Unmarshal", func() {
 		Context("maps", func() {
 			It("unmarshals maps with interface values", func() {
 				By("map", func() {
-					var s struct{ I map[string]interface{} }
+					var s struct{ I map[string]any }
 					unmarshal(&s, `{"I":{"a":"b","c":5,"d":true}}`)
-					Expect(s.I).To(Equal(map[string]interface{}{"a": "b", "c": 5, "d": true}))
+					Expect(s.I).To(Equal(map[string]any{"a": "b", "c": 5, "d": true}))
 				})
 
 				By("pointer", func() {
-					var s struct{ I *map[string]interface{} }
+					var s struct{ I *map[string]any }
 					unmarshal(&s, `{"I":{"a":"b","c":5,"d":true}}`)
-					Expect(s.I).To(PointTo(Equal(map[string]interface{}{"a": "b", "c": 5, "d": true})))
+					Expect(s.I).To(PointTo(Equal(map[string]any{"a": "b", "c": 5, "d": true})))
 				})
 			})
 
@@ -356,14 +356,14 @@ var _ = Describe("Unmarshal", func() {
 
 			It("unmarshals omitted maps", func() {
 				By("map", func() {
-					var s struct{ I map[string]interface{} }
+					var s struct{ I map[string]any }
 					unmarshal(&s, `{}`)
 					Expect(s.I).To(BeNil())
 					Expect(s.I).To(BeEmpty())
 				})
 
 				By("pointer", func() {
-					var s struct{ I *map[string]interface{} }
+					var s struct{ I *map[string]any }
 					unmarshal(&s, `{}`)
 					Expect(s.I).To(BeNil())
 				})
@@ -371,14 +371,14 @@ var _ = Describe("Unmarshal", func() {
 
 			It("unmarshals null maps", func() {
 				By("map", func() {
-					var s struct{ I map[string]interface{} }
+					var s struct{ I map[string]any }
 					unmarshal(&s, `{"I": null}`)
 					Expect(s.I).To(BeNil())
 					Expect(s.I).To(BeEmpty())
 				})
 
 				By("pointer", func() {
-					var s struct{ I *map[string]interface{} }
+					var s struct{ I *map[string]any }
 					unmarshal(&s, `{"I": null}`)
 					Expect(s.I).To(BeNil())
 				})
@@ -386,14 +386,14 @@ var _ = Describe("Unmarshal", func() {
 
 			It("unmarshals empty maps", func() {
 				By("map", func() {
-					var s struct{ I map[string]interface{} }
+					var s struct{ I map[string]any }
 					unmarshal(&s, `{"I": {}}`)
 					Expect(s.I).NotTo(BeNil())
 					Expect(s.I).To(BeEmpty())
 				})
 
 				By("pointer", func() {
-					var s struct{ I *map[string]interface{} }
+					var s struct{ I *map[string]any }
 					unmarshal(&s, `{"I": {}}`)
 					Expect(s.I).NotTo(BeNil())
 					Expect(s.I).To(PointTo(Not(BeNil())))
@@ -481,7 +481,7 @@ var _ = Describe("Unmarshal", func() {
 			})
 
 			It("overwrites an interface{} as nil", func() {
-				s := struct{ S interface{} }{S: "hello"}
+				s := struct{ S any }{S: "hello"}
 				unmarshal(&s, `{"S": null}`)
 				Expect(s.S).To(BeNil())
 			})


### PR DESCRIPTION
The modernize command replaces old constructs with simpler, updated ones.

Command is:
go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -fix -test ./...